### PR TITLE
Fix denoising sampling

### DIFF
--- a/dalle2_pytorch/dalle2_pytorch.py
+++ b/dalle2_pytorch/dalle2_pytorch.py
@@ -590,8 +590,7 @@ class DiffusionPrior(nn.Module):
         return x_recon + nonzero_mask * (0.5 * model_log_variance).exp() * noise
 
     @torch.no_grad()
-    def 
-    _loop(self, shape, text_cond):
+    def p_sample_loop(self, shape, text_cond):
         device = self.betas.device
 
         b = shape[0]


### PR DESCRIPTION
The `q_posterior` function as implemented is not correct and is not needed for sampling. Recall in Ho et al. equation (7) is for `x_0` which is not known during sampling.

And in Alg. 2 line 4 we just need the slightly denoised sample.

Issue flagged to me by @NielsRogge so all credit to him if I am not mistaken... and if I am mistaken then it's my fault!