### PR TITLE
Patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#Project directories
+wandb/
+diffusion_prior_checkpoints/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     'text to image'
   ],
   install_requires=[
+    'aiohttp>=3.8.0',
     'click',
     'clip-anytorch',
     'coca-pytorch>=0.0.5',
@@ -39,6 +40,7 @@ setup(
     'vector-quantize-pytorch',
     'x-clip>=0.4.4',
     'youtokentome',
+    'wandb>=0.12.16',
     'webdataset>=0.2.5',
     'fsspec>=2022.1.0'
   ],


### PR DESCRIPTION
Added two modules which were missing from the install_requires list in setup.py; aiohttp and wandb.
Also added `wandb/` and `diffusion_prior_checkpoints/` to the .gitignore