### PR TITLE
Migrate to text-conditioned prior training

### DIFF
--- a/dalle2_pytorch/dalle2_pytorch.py
+++ b/dalle2_pytorch/dalle2_pytorch.py
@@ -1890,6 +1890,11 @@ class Decoder(BaseGaussianDiffusion):
             # return simple loss if not using learned variance
             return loss
 
+        # most of the code below is transcribed from
+        # https://github.com/hojonathanho/diffusion/blob/master/diffusion_tf/diffusion_utils_2.py
+        # the Improved DDPM paper then further modified it so that the mean is detached (shown a couple lines before), and weighted to be smaller than the l1 or l2 "simple" loss
+        # it is questionable whether this is really needed, looking at some of the figures in the paper, but may as well stay faithful to their implementation
+
         # if learning the variance, also include the extra weight kl loss
 
         true_mean, _, true_log_variance_clipped = self.q_posterior(x_start = x_start, x_t = x_noisy, t = times)

--- a/dalle2_pytorch/dataloaders/__init__.py
+++ b/dalle2_pytorch/dataloaders/__init__.py
@@ -1,1 +1,2 @@
 from dalle2_pytorch.dataloaders.decoder_loader import ImageEmbeddingDataset, create_image_embedding_dataloader
+from dalle2_pytorch.dataloaders.embedding_wrapper import make_splits

--- a/dalle2_pytorch/dataloaders/embedding_wrapper.py
+++ b/dalle2_pytorch/dataloaders/embedding_wrapper.py
@@ -173,7 +173,7 @@ def make_splits(
             text_reader=text_reader,
             batch_size=batch_size,
             start=eval_stop,
-            stop=num_data_points,
+            stop=int(num_data_points),
             device=device,
         )
 

--- a/dalle2_pytorch/dataloaders/embedding_wrapper.py
+++ b/dalle2_pytorch/dataloaders/embedding_wrapper.py
@@ -20,7 +20,7 @@ class PriorEmbeddingLoader(IterableDataset):
         self.text_conditioned = text_conditioned
 
         if not self.text_conditioned:
-            self.text_reader = image_reader
+            self.text_reader = text_reader
 
         self.image_reader = image_reader
         self.batch_size = batch_size

--- a/dalle2_pytorch/dataloaders/embedding_wrapper.py
+++ b/dalle2_pytorch/dataloaders/embedding_wrapper.py
@@ -1,0 +1,167 @@
+from torch.utils.data import IterableDataset
+from torch import from_numpy
+from clip import tokenize
+from embedding_reader import EmbeddingReader
+
+
+class PriorEmbeddingLoader(IterableDataset):
+    def __init__(
+        self,
+        text_conditioned: bool,
+        batch_size: int,
+        start: int,
+        stop: int,
+        image_reader,
+        text_reader: EmbeddingReader = None,
+        device: str = "cpu",
+    ) -> None:
+        super(PriorEmbeddingLoader).__init__()
+
+        self.text_conditioned = text_conditioned
+
+        if not self.text_conditioned:
+            self.text_reader = image_reader
+
+        self.image_reader = image_reader
+        self.batch_size = batch_size
+        self.start = start
+        self.stop = stop
+        self.device = device
+
+    def __iter__(self):
+        self.n = 0
+        loader_args = dict(
+            batch_size=self.batch_size,
+            start=self.start,
+            end=self.stop,
+            show_progress=False,
+        )
+        if self.text_conditioned:
+            self.loader = self.image_reader(**loader_args)
+        else:
+            self.loader = zip(
+                self.image_reader(**loader_args), self.text_reader(**loader_args)
+            )
+        return self
+
+    def __next__(self):
+        try:
+            return self.get_sample()
+        except StopIteration:
+            raise StopIteration
+
+    def get_sample(self):
+        """
+        pre-proocess data from either reader into a common format
+        """
+        self.n += 1
+
+        if self.text_conditioned:
+            image_embedding, caption = next(self.loader)
+
+            image_embedding = from_numpy(image_embedding).to(self.device)
+            tokenized_caption = tokenize(
+                caption["caption"].to_list(), truncate=True
+            ).to(self.device)
+
+            return image_embedding, tokenized_caption
+
+        else:
+            (image_embedding, _), (text_embedding, _) = next(self.loader)
+
+            image_embedding = from_numpy(image_embedding).to(self.device)
+            text_embedding = from_numpy(text_embedding).to(self.device)
+
+            return image_embedding, text_embedding
+
+
+def make_splits(
+    text_conditioned: bool,
+    batch_size: int,
+    num_data_points: int,
+    train_split: float,
+    eval_split: float,
+    device: str,
+    img_url: str,
+    meta_url: str = None,
+    txt_url: str = None,
+):
+
+    assert img_url is not None, "Must supply some image embeddings"
+
+    # compute split points
+    train_set_size = int(train_split * num_data_points)
+    eval_set_size = int(eval_split * num_data_points)
+    eval_stop = train_set_size + eval_set_size
+
+    if text_conditioned:
+        assert meta_url is not None, "Must supply metadata url if text-conditioning"
+        image_reader = EmbeddingReader(
+            img_url,
+            file_format="parquet_npy",
+            meta_columns=["caption"],
+            metadata_folder=meta_url,
+        )
+
+        train_loader = PriorEmbeddingLoader(
+            text_conditioned=text_conditioned,
+            image_reader=image_reader,
+            batch_size=batch_size,
+            start=0,
+            stop=train_set_size,
+            device=device,
+        )
+        eval_loader = PriorEmbeddingLoader(
+            text_conditioned=text_conditioned,
+            image_reader=image_reader,
+            batch_size=batch_size,
+            start=train_set_size,
+            stop=eval_stop,
+            device=device,
+        )
+        test_loader = PriorEmbeddingLoader(
+            text_conditioned=text_conditioned,
+            image_reader=image_reader,
+            batch_size=batch_size,
+            start=eval_stop,
+            stop=num_data_points,
+            device=device,
+        )
+
+    else:
+        assert (
+            txt_url is not None
+        ), "Must supply text embedding url if not text-conditioning"
+
+        image_reader = EmbeddingReader(img_url, file_format="npy")
+        text_reader = EmbeddingReader(txt_url, file_format="npy")
+
+        train_loadeer = PriorEmbeddingLoader(
+            text_conditioned=text_conditioned,
+            image_reader=image_reader,
+            text_reader=text_reader,
+            batch_size=batch_size,
+            start=0,
+            stop=train_set_size,
+            device=device,
+        )
+        eval_loader = PriorEmbeddingLoader(
+            text_conditioned=text_conditioned,
+            image_reader=image_reader,
+            text_reader=text_reader,
+            batch_size=batch_size,
+            start=train_set_size,
+            stop=eval_stop,
+            device=device,
+        )
+        test_loader = PriorEmbeddingLoader(
+            text_conditioned=text_conditioned,
+            image_reader=image_reader,
+            text_reader=text_reader,
+            batch_size=batch_size,
+            start=eval_stop,
+            stop=num_data_points,
+            device=device,
+        )
+
+    return train_loader, eval_loader, test_loader

--- a/train_diffusion_prior.py
+++ b/train_diffusion_prior.py
@@ -150,7 +150,7 @@ def report_cosine_sims(diffusion_prior, dataloader, text_conditioned):
 @click.option("--dropout", default=5e-2)
 @click.option("--max-grad-norm", default=0.5)
 @click.option("--num-data-points", default=250e6)
-@click.option("--batch-size", default=256)
+@click.option("--batch-size", default=320)
 @click.option("--num-epochs", default=5)
 @click.option("--image-embed-dim", default=768)
 @click.option("--train-percent", default=0.7)
@@ -160,13 +160,13 @@ def report_cosine_sims(diffusion_prior, dataloader, text_conditioned):
 @click.option("--dpn-dim-head", default=64)
 @click.option("--dpn-heads", default=12)
 @click.option("--dp-condition-on-text-encodings", default=True)
-@click.option("--dp-timesteps", default=100)
+@click.option("--dp-timesteps", default=1000)
 @click.option("--dp-normformer", default=True)
 @click.option("--dp-cond-drop-prob", default=0.1)
 @click.option("--dp-loss-type", default="l2")
 @click.option("--clip", default="ViT-L/14")
 @click.option("--amp", default=False)
-@click.option("--save-interval", default=30)
+@click.option("--save-interval", default=120)
 @click.option("--save-path", default="./diffusion_prior_checkpoints")
 @click.option("--pretrained-model-path", default=None)
 @click.option("--gpu-device", default=0)
@@ -363,6 +363,7 @@ def train(
                 ### Evaluate model(validation run) ###
                 eval_model(diffusion_prior, eval_loader, dp_condition_on_text_encodings, dp_loss_type, phase="Validation")
 
+            step += 1
             trainer.update()
 
     ### Test run ###

--- a/train_diffusion_prior.py
+++ b/train_diffusion_prior.py
@@ -59,7 +59,7 @@ def eval_model(model, dataloader, text_conditioned, loss_type, phase="Validation
 
             loss = model(**input_args)
 
-            total_loss += loss.item() * batches
+            total_loss += loss * batches
             total_samples += batches
 
         avg_loss = (total_loss / total_samples)
@@ -122,15 +122,15 @@ def report_cosine_sims(diffusion_prior, dataloader, text_conditioned):
             predicted_unrelated_embeddings.norm(dim=1, keepdim=True)
 
         # calculate similarities
-       original_similarity = cos(
+        original_similarity = cos(
            text_embed, test_image_embeddings).cpu().numpy()
-       predicted_similarity = cos(
+        predicted_similarity = cos(
            text_embed, predicted_image_embeddings).cpu().numpy()
-       unrelated_similarity = cos(
+        unrelated_similarity = cos(
            text_embed, predicted_unrelated_embeddings).cpu().numpy()
-       predicted_img_similarity = cos(
+        predicted_img_similarity = cos(
            test_image_embeddings, predicted_image_embeddings).cpu().numpy()
-       tracker.log({"CosineSimilarity(text_embed,image_embed)": np.mean(original_similarity),
+        tracker.log({"CosineSimilarity(text_embed,image_embed)": np.mean(original_similarity),
             "CosineSimilarity(text_embed,predicted_image_embed)":np.mean(predicted_similarity),
             "CosineSimilarity(orig_image_embed,predicted_image_embed)":np.mean(predicted_img_similarity),
             "CosineSimilarity(text_embed,predicted_unrelated_embed)": np.mean(unrelated_similarity),
@@ -150,21 +150,21 @@ def report_cosine_sims(diffusion_prior, dataloader, text_conditioned):
 @click.option("--dropout", default=5e-2)
 @click.option("--max-grad-norm", default=0.5)
 @click.option("--num-data-points", default=250e6)
-@click.option("--batch-size", default=10**4)
+@click.option("--batch-size", default=256)
 @click.option("--num-epochs", default=5)
 @click.option("--image-embed-dim", default=768)
 @click.option("--train-percent", default=0.7)
 @click.option("--val-percent", default=0.2)
 @click.option("--test-percent", default=0.1)
-@click.option("--dpn-depth", default=6)
+@click.option("--dpn-depth", default=12)
 @click.option("--dpn-dim-head", default=64)
-@click.option("--dpn-heads", default=8)
-@click.option("--dp-condition-on-text-encodings", default=False)
+@click.option("--dpn-heads", default=12)
+@click.option("--dp-condition-on-text-encodings", default=True)
 @click.option("--dp-timesteps", default=100)
-@click.option("--dp-normformer", default=False)
+@click.option("--dp-normformer", default=True)
 @click.option("--dp-cond-drop-prob", default=0.1)
 @click.option("--dp-loss-type", default="l2")
-@click.option("--clip", default=None)
+@click.option("--clip", default="ViT-L/14")
 @click.option("--amp", default=False)
 @click.option("--save-interval", default=30)
 @click.option("--save-path", default="./diffusion_prior_checkpoints")
@@ -229,7 +229,7 @@ def train(
 
     # Check if DPRIOR_PATH exists(saved model path)
 
-    DPRIOR_PATH = args.pretrained_model_path
+    DPRIOR_PATH = pretrained_model_path
     RESUME = exists(DPRIOR_PATH)
 
     if not RESUME:
@@ -352,7 +352,7 @@ def train(
                     image_embed_dim)
 
             # Log to wandb
-            tracker.log({"Training loss": loss.item(),
+            tracker.log({"Training loss": loss,
                         "Steps": step,
                         "Samples per second": samples_per_sec})
             # Log cosineSim(text_embed,predicted_image_embed) - cosineSim(text_embed,image_embed)

--- a/train_diffusion_prior.py
+++ b/train_diffusion_prior.py
@@ -18,8 +18,7 @@ from tqdm import tqdm
 
 # constants
 
-NUM_TEST_EMBEDDINGS = 100 # for cosine similarity reporting during training
-REPORT_METRICS_EVERY = 100 # for cosine similarity and other metric reporting during training
+REPORT_METRICS_EVERY = 250 # for cosine similarity and other metric reporting during training
 
 tracker = WandbTracker()
 
@@ -37,6 +36,7 @@ class Timer:
 
     def elapsed(self):
         return time.time() - self.last_time
+
 # functions
 
 def eval_model(model, dataloader, text_conditioned, loss_type, phase="Validation"):
@@ -45,7 +45,6 @@ def eval_model(model, dataloader, text_conditioned, loss_type, phase="Validation
     with torch.no_grad():
         total_loss = 0.
         total_samples = 0.
-
 
         for image_embeddings, text_data in tqdm(dataloader):
 
@@ -153,9 +152,9 @@ def report_cosine_sims(diffusion_prior, dataloader, text_conditioned):
 @click.option("--batch-size", default=320)
 @click.option("--num-epochs", default=5)
 @click.option("--image-embed-dim", default=768)
-@click.option("--train-percent", default=0.7)
-@click.option("--val-percent", default=0.2)
-@click.option("--test-percent", default=0.1)
+@click.option("--train-percent", default=0.9)
+@click.option("--val-percent", default=1e-7)
+@click.option("--test-percent", default=0.0999999)
 @click.option("--dpn-depth", default=12)
 @click.option("--dpn-dim-head", default=64)
 @click.option("--dpn-heads", default=12)


### PR DESCRIPTION
removed text embedding reader and opted to compute encodings and embeddings at train-time.

& some defaults changes pertaining to the switch, as well as making the default model larger (per Katherine's anecdotal evidence)