### PR TITLE
[FIX #115] Use deterministic optimizer parameters

### DIFF
--- a/dalle2_pytorch/optimizer.py
+++ b/dalle2_pytorch/optimizer.py
@@ -21,8 +21,6 @@ def get_optimizer(
     if wd == 0:
         return Adam(params, lr = lr, betas = betas, eps = eps)
 
-    params = set(params)
-
     if group_wd_params:
         wd_params, no_wd_params = separate_weight_decayable_params(params)
 


### PR DESCRIPTION
caught this in the PyTorch source code when digging a little deeper into #115 

> **warning:** Parameters need to be specified as collections that have a deterministic
ordering that is consistent between runs. **Examples of objects that don't
satisfy those properties are ***`sets`*** and iterators over values of dictionaries.**

---

If there's concern that there are a lot of duplicate key/value pairs in the model parameters, perhaps we can look into some other deterministic iterable that's both deterministic and unique, but this seems to solve the issue that I was running into...
