### PR TITLE
bibtex typo for max_vit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,7 +1140,7 @@ This library would not have gotten to this working state without the help of
 ```bibtex
 @inproceedings{Tu2022MaxViTMV,
     title   = {MaxViT: Multi-Axis Vision Transformer},
-    author  = {Zhe-Wei Tu and Hossein Talebi and Han Zhang and Feng Yang and Peyman Milanfar and Alan Conrad Bovik and Yinxiao Li},
+    author  = {Zhengzhong Tu and Hossein Talebi and Han Zhang and Feng Yang and Peyman Milanfar and Alan Conrad Bovik and Yinxiao Li},
     year    = {2022}
 }
 ```


### PR DESCRIPTION
Hi @lucidrains, thanks for referencing max_vit!! But found this typo again =). 

Just wondering if the `grid attention` you posted in the to-do list is from our paper? If so, I'd sincerely appreciate it if you can add the arxiv paper link in the item just like other items~ 
https://arxiv.org/abs/2204.01697