### PR TITLE
fix bug of TypeError

### DIFF
--- a/train_decoder.py
+++ b/train_decoder.py
@@ -347,7 +347,7 @@ def train(
         # Compute evaluation metrics
         if exists(evaluate_config):
             print(print_ribbon(f"Starting Evaluation {epoch}", repeat=40))
-            evaluation = evaluate_trainer(trainer, dataloaders["val"], inference_device, **evaluate_config)
+            evaluation = evaluate_trainer(trainer, dataloaders["val"], inference_device, **evaluate_config.__dict__)
             tracker.log(evaluation, step=step, verbose=True)
 
         # Generate sample images


### PR DESCRIPTION
Traceback (most recent call last):
...
  File "/data/DALLE2-pytorch/train_decoder.py", line 350, in train
    evaluation = evaluate_trainer(trainer, dataloaders["val"], inference_device, **evaluate_config)
TypeError: evaluate_trainer() argument after ** must be a mapping, not DecoderEvaluateConfig