### PR TITLE
Add packaging library to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     'embedding-reader',
     'kornia>=0.5.4',
     'numpy',
+    'packaging',
     'pillow',
     'pydantic',
     'resize-right>=0.0.2',


### PR DESCRIPTION
The `packaging` library in one of your most recent commits (https://github.com/lucidrains/DALLE2-pytorch/commit/b588286288b8b0bb3e3a7132ddc3a3643629e456) may not already be installed on a user's device, so it should be in the `setup.py`.