### PR TITLE
changed str in order to avoid confusions and collisions with Python

### DIFF
--- a/dalle2_pytorch/vqgan_vae.py
+++ b/dalle2_pytorch/vqgan_vae.py
@@ -68,8 +68,8 @@ def group_dict_by_key(cond, d):
         return_val[ind][key] = d[key]
     return (*return_val,)
 
-def string_begins_with(prefix, str):
-    return str.startswith(prefix)
+def string_begins_with(prefix, string_input):
+    return string_input.startswith(prefix)
 
 def group_by_key_prefix(prefix, d):
     return group_dict_by_key(partial(string_begins_with, prefix), d)


### PR DESCRIPTION
Οverriding reserved words with your own will lead to confusion.

I will recommend to avoid using built-in names of Python, in order to avoid any collisions. 

so if you try the example below you will observe that local name overshadow the built-in str, rendering them un-usable.

![image](https://user-images.githubusercontent.com/47610789/173920500-98161178-737c-4ed1-9b1e-5f661e56ffca.png)

Great work @lucidrains ! I would like to contribute more on this code
