### PR TITLE
autoswitch tqdm for notebooks

### DIFF
--- a/dalle2_pytorch/dalle2_pytorch.py
+++ b/dalle2_pytorch/dalle2_pytorch.py
@@ -1,6 +1,6 @@
 import math
 import random
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from functools import partial, wraps
 from contextlib import contextmanager
 from collections import namedtuple


### PR DESCRIPTION
avoids printing the `tqdm` progress bar to a newline in notebooks when detected