### PR TITLE
Add deepspeed support for decoder training

### DIFF
--- a/dalle2_pytorch/dataloaders/decoder_loader.py
+++ b/dalle2_pytorch/dataloaders/decoder_loader.py
@@ -1,6 +1,7 @@
 import os
 import webdataset as wds
 import torch
+from torch.utils.data import DataLoader
 import numpy as np
 import fsspec
 import shutil
@@ -255,7 +256,7 @@ def create_image_embedding_dataloader(
     )
     if shuffle_num is not None and shuffle_num > 0:
         ds.shuffle(1000)
-    return wds.WebLoader(
+    return DataLoader(
         ds,
         num_workers=num_workers,
         batch_size=batch_size,

--- a/train_decoder.py
+++ b/train_decoder.py
@@ -279,6 +279,7 @@ def train(
     trainer = DecoderTrainer(
         decoder=decoder,
         accelerator=accelerator,
+        dataloaders=dataloaders,
         **kwargs
     )
 
@@ -326,7 +327,7 @@ def train(
         last_snapshot = sample
 
         if next_task == 'train':
-            for i, (img, emb, txt) in enumerate(dataloaders["train"]):
+            for i, (img, emb, txt) in enumerate(trainer.train_loader):
                 # We want to count the total number of samples across all processes
                 sample_length_tensor[0] = len(img)
                 all_samples = accelerator.gather(sample_length_tensor)  # TODO: accelerator.reduce is broken when this was written. If it is fixed replace this.
@@ -419,7 +420,7 @@ def train(
             timer = Timer()
             accelerator.wait_for_everyone()
             i = 0
-            for i, (img, emb, txt) in enumerate(dataloaders["val"]):
+            for i, (img, emb, txt) in enumerate(trainer.val_loader):  # Use the accelerate prepared loader
                 val_sample_length_tensor[0] = len(img)
                 all_samples = accelerator.gather(val_sample_length_tensor)
                 total_samples = all_samples.sum().item()


### PR DESCRIPTION
In order to train decoders of the size openAI uses, we need the optimizations deepspeed offers. This pull request changes initialization of the trainer to abide by what deepspeed requests.

Functionality:
- [x] Zero
- [ ] Text conditioning support
- [x] fp16

Getting fp16 working is our main concern at the moment as it is required to train larger models. Unfortunatly, when it is enabled, we get overflow warnings and infinities start appearing. The logging that appears is below.

Without anomaly detection enabled: [logs](https://pastebin.com/q5ua63Rs)

With anomaly detection enabled: [logs](https://pastebin.com/2aUYqGhe)

We are exploring solutions, but if you have any insight it would be appreciated. I was thinking it might have to do with https://github.com/pytorch/pytorch/issues/41527, but I did not see any difference when varying eps.