### PR TITLE
Add Deepspeed Support

### DIFF
--- a/dalle2_pytorch/dataloaders/decoder_loader.py
+++ b/dalle2_pytorch/dataloaders/decoder_loader.py
@@ -1,6 +1,7 @@
 import os
 import webdataset as wds
 import torch
+from torch.utils.data import DataLoader
 import numpy as np
 import fsspec
 import shutil
@@ -255,7 +256,7 @@ def create_image_embedding_dataloader(
     )
     if shuffle_num is not None and shuffle_num > 0:
         ds.shuffle(1000)
-    return wds.WebLoader(
+    return DataLoader(
         ds,
         num_workers=num_workers,
         batch_size=batch_size,


### PR DESCRIPTION
In order to train decoders of the size openAI uses, we need the optimizations deepspeed offers. This pull request changes initialization of the trainer to abide by what deepspeed requests.

Functionality:
- [x] Zero stages 0, 1, and 2
- [x] Text conditioning support
- [x] fp16
- [x] bf16

This pull request does not add support for multi-node training since accelerate currently does not support deepspeed mutli-node. Adding that to this repository in particular is possible, but will take some research to implement and is out of the scope of this particular change.